### PR TITLE
Taking only Non Private Repo of the User

### DIFF
--- a/server/controllers/user.controller.js
+++ b/server/controllers/user.controller.js
@@ -90,7 +90,7 @@ function getProjects (req, res, next) {
       if(!err) {
         const repos = response.body;
         if (repos.length > 0) {
-          res.json(repos.filter(repo => repo.owner.login === user.github.account));
+          res.json(repos.filter(repo => repo.owner.login === user.github.account && repo.private === false));
         } else {
           res.status(404);
         }


### PR DESCRIPTION
When we call the GitHub we get all the repository of the user. If there is any private repo, we should not get it.