### PR TITLE
Fix Maximum/Minimum Votes

### DIFF
--- a/utopian-bot.js
+++ b/utopian-bot.js
@@ -376,7 +376,9 @@ conn.once('open', function ()
                                         'muxxybot'
                                       ];
 
-
+                                      // minimum and maximum Vote
+                                      const minVote = 1;
+                                      const maxVote = 60;
                                       const reputation = steem.formatter.reputation(account.reputation);
 
                                       const categoryStats = categories[post.json_metadata.type];
@@ -640,8 +642,8 @@ conn.once('open', function ()
                                       }
 
                                       vote = Math.round(vote);
-                                      if(vote <= 0) vote = 1;
-                                      if(vote > 100) vote = 60;
+                                      if(vote < minVote) vote = minVote;
+                                      if(vote > maxVote) vote = maxVote;
 
 
 


### PR DESCRIPTION
@elear's commit [here](https://github.com/utopian-io/api.utopian.io/commit/5cb888c119406dbc0b4d32373c23a0606ceefec4) was meant to change the maximum vote to 60, yet instead it still allowed votes of above 60.

It changed the code to `if (vote > 100) vote = 60;` which means if the vote was above 100, it would default to 60. However, what if the vote was at 99%? Then, it would not default to 60 which means the 'max vote limit' of 60 wouldn't be required.

My commit allows the max/min vote functionality to work as it's supposed to, using new `const`s to allow you to easily change these parameters. 

Thanks!