### PR TITLE
Update Bot List

### DIFF
--- a/utopian-bot.js
+++ b/utopian-bot.js
@@ -25,7 +25,6 @@ conn.once('open', function ()
   const MAX_USABLE_POOL = 10000;
 
   const bots = [
-    'analisa',
     'animus',
     'appreciator',
     'arama',


### PR DESCRIPTION
Update Bot List = Removed 'Analisa'. As per Tom/@donkeypong. Ana is a real person and they have control of the account, it's part of their curation that votes together with Donkeypong and Kevingwong. Previously Ana votes separately but to provide assistance to Tom's advocacies, they've coupled the accounts that they have when voting.