### PR TITLE
Allowing for Scope Versions

### DIFF
--- a/src/server/controllers/user.controller.ts
+++ b/src/server/controllers/user.controller.ts
@@ -111,7 +111,7 @@ function getProjects (req, res, next) {
  * @returns {User}
  */
 function create(req, res, next) {
-  const { account, code, state } = req.body;
+  const { account, code, state, scopeVersion } = req.body;
 
   if (code && state) {
     request.post('https://github.com/login/oauth/access_token')
@@ -141,6 +141,7 @@ function create(req, res, next) {
                     user.github = {
                       account: githubUserName,
                       token: access_token,
+                      scopeVersion: scopeVersion,
                       ...githubUser,
                     };
                     user.save()
@@ -153,6 +154,7 @@ function create(req, res, next) {
                         github: {
                           account: githubUserName,
                           token: access_token,
+                          scopeVersion: scopeVersion,
                           ...githubUser,
                         }
                       });


### PR DESCRIPTION
This is necessary so that we can ask people on an earlier/not up-to-date scope version to reconnect with Github.

For example, if I change the scope URL on @utopian-io/utopian.io which I'm doing right now (for organizations) I need a way of asking people on the old scope URL to reconnect. This scopeVersion can be used for this.