### PR TITLE
Update blog posts weight on mod reward payments

### DIFF
--- a/src/utopian-mod-pay/index.ts
+++ b/src/utopian-mod-pay/index.ts
@@ -62,8 +62,8 @@ const CATEGORY_VALUE: { [key: string]: CategoryValue } = {
     flagged: 0.50
   },
   blog: {
-    reviewed: 0.50,
-    flagged: 0.50
+    reviewed: 0.75,
+    flagged: 0.75
   },
   'video-tutorials': {
     reviewed: 1,


### PR DESCRIPTION
Blog posts category is an underrated category on moderation points.

1. You need to actually read every inch of the content instead of skimming.
2. You need to check google or other plagiarism sources to check the contribution is copy/pasta. However, this is not enough, most authors also are very talented on plagiarism they do rephrase plagiarism. So, if the user has a suspicious profile, you should also need to check related blog posts, publications in the internets.

3. You should also check the relevancy of the content. Authors tend to post wrong content. [Example thread](https://steemit.com/utopian-io/@nilesh.katuwal/python-programming-language-or-or-what-is-cpython#@emrebeyler/re-nileshkatuwal-re-emrebeyler-re-nileshkatuwal-python-programming-language-or-or-what-is-cpython-20180119t062855515z)
4. You should give authors detailed feedback which takes 5 minutes of writing time for comments.

I would say, an average blog post review time is around 20-30 mins.

Overall, blog posts with 0.50 weighted points are not fair compared with other categories.
