### PR TITLE
Fix moderator filter when querying posts on /post/moderator

### DIFF
--- a/src/server/controllers/post.controller/moderator/aggregate.ts
+++ b/src/server/controllers/post.controller/moderator/aggregate.ts
@@ -6,13 +6,11 @@ export function aggregateMatch(startDate: Date | undefined, endDate: Date, moder
             'json_metadata.moderator.time': {
                 $lt: endDate.toISOString()
             },
-
         }
     };
 
     if (startDate) {
         matcher.$match['json_metadata.moderator.time'].$gte = startDate.toISOString();
-
     }
 
     if (moderator) {
@@ -21,17 +19,18 @@ export function aggregateMatch(startDate: Date | undefined, endDate: Date, moder
 
     switch (status) {
         case PostStatus.ANY:
-            matcher.$match['json_metadata.moderator.account'] = {  $ne: null };
+            if (!moderator) 
+                matcher.$match['json_metadata.moderator.account'] = {  $ne: null };
             break;
         case PostStatus.REVIEWED:
             matcher.$match['json_metadata.moderator.reviewed'] = true;
             break;
-        case PostStatus.PENDING:
-            matcher.$match['json_metadata.moderator.pending'] = true;
-            break;    
         case PostStatus.FLAGGED:
             matcher.$match['json_metadata.moderator.flagged'] = true;
-            break
+            break;
+        case PostStatus.PENDING:
+            matcher.$match['json_metadata.moderator.pending'] = true;
+            break;
     }
     return matcher;
 }


### PR DESCRIPTION
If I wanted a post with any status from a specific moderator, I couldn't get it, because the `switch case` changed the moderator query to `{  $ne: null }`, so I did a check to see if there's a moderator to query