### PR TITLE
Hotfix for repo emptied on category inline edit

### DIFF
--- a/src/server/controllers/post.controller/index.ts
+++ b/src/server/controllers/post.controller/index.ts
@@ -77,7 +77,7 @@ async function update(req, res, next) {
   const pending = getBoolean(req.body.pending);
   const reviewed = getBoolean(req.body.reviewed);
   const contribType = req.body.type || null;
-  const repo = req.body.repository || {};
+  const repo = req.body.repository || null;
 
   const questions = req.body.questions || [];
   const score = req.body.score ? parseFloat(req.body.score) : 0;


### PR DESCRIPTION
Refs issue [#411](https://github.com/utopian-io/utopian.io/issues/411) in the front-end.

![hotfix-repo-emptied-on-category-inline-edit](https://user-images.githubusercontent.com/29425738/36602704-a91987b0-18f3-11e8-9404-270ca09e9e8e.gif)
